### PR TITLE
better performance using array of listeners

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,23 +2,25 @@
 var pushable = require('pull-pushable')
 
 module.exports = function () {
-
-  var listeners = {}, n = 0
+  var listeners = {}
+  var n = 0
 
   function notify (msg) {
-    for(var k in listeners) listeners[k].push(msg)
+    for (var k in listeners) listeners[k].push(msg)
     return msg
   }
 
   notify.listen = function () {
     var k = ++n
-    return listeners[k] = pushable(function () {
+    var listener = pushable(function () {
       delete listeners[k]
     })
+    listeners[k] = listener
+    return listener
   }
 
   notify.abort = function (err) {
-    for(var k in listeners) listeners[k].end(err)
+    for (var k in listeners) listeners[k].end(err)
   }
 
   notify.end = function () {

--- a/index.js
+++ b/index.js
@@ -2,25 +2,30 @@
 var pushable = require('pull-pushable')
 
 module.exports = function () {
-  var listeners = {}
-  var n = 0
+  var listeners = []
 
-  function notify (msg) {
-    for (var k in listeners) listeners[k].push(msg)
-    return msg
+  function notify (message) {
+    // notify by pushing to all listeners
+    for (var i = 0; i < listeners.length; i++) {
+      listeners[i].push(message)
+    }
+    return message
   }
 
   notify.listen = function () {
-    var k = ++n
-    var listener = pushable(function () {
-      delete listeners[k]
+    // create listener with `onClose` handler
+    var listener = pushable(function onClose () {
+      // if listener is found, delete from list
+      var index = listeners.indexOf(listener)
+      if (index !== -1) listeners.splice(index, 1)
     })
-    listeners[k] = listener
+    listeners.push(listener)
     return listener
   }
 
   notify.abort = function (err) {
-    for (var k in listeners) listeners[k].end(err)
+    // abort by ending all listeners
+    while (listeners.length) listeners[0].end(err)
   }
 
   notify.end = function () {

--- a/package.json
+++ b/package.json
@@ -12,11 +12,12 @@
   },
   "devDependencies": {
     "pull-stream": "^3.0.1",
+    "standard": "^7.1.2",
     "tape": "~4.0.0"
   },
   "scripts": {
-    "prepublish": "npm ls &&  npm test",
-    "test": "set -e; for t in test/*.js; do node $t; done"
+    "prepublish": "npm ls && npm test",
+    "test": "standard && tape test/*.js"
   },
   "author": "Dominic Tarr <dominic.tarr@gmail.com> (http://dominictarr.com)",
   "license": "MIT"

--- a/test/index.js
+++ b/test/index.js
@@ -4,8 +4,8 @@ var tape = require('tape')
 var pull = require('pull-stream')
 
 tape('simple', function (t) {
-
-  var notify = Notify(), r = Math.random()
+  var notify = Notify()
+  var r = Math.random()
 
   pull(
     notify.listen(),
@@ -20,17 +20,17 @@ tape('simple', function (t) {
   notify.end()
 })
 
-
 tape('end', function (t) {
-
-  var notify = Notify(), r = Math.random(), n = 3
+  var notify = Notify()
+  var r = Math.random()
+  var n = 3
 
   pull(
     notify.listen(),
     pull.drain(function (data) {
       t.equal(data, r)
     }, function () {
-      if(--n) return
+      if (--n) return
       t.end()
     })
   )
@@ -39,7 +39,7 @@ tape('end', function (t) {
     pull.drain(function (data) {
       t.equal(data, r)
     }, function () {
-      if(--n) return
+      if (--n) return
       t.end()
     })
   )
@@ -48,7 +48,7 @@ tape('end', function (t) {
     pull.drain(function (data) {
       t.equal(data, r)
     }, function () {
-      if(--n) return
+      if (--n) return
       t.end()
     })
   )
@@ -58,8 +58,8 @@ tape('end', function (t) {
 })
 
 tape('simple', function (t) {
-
-  var notify = Notify(), r = Math.random()
+  var notify = Notify()
+  var r = Math.random()
 
   pull(
     notify.listen(),
@@ -73,5 +73,3 @@ tape('simple', function (t) {
   t.equal(notify(r), r)
   notify.end()
 })
-
-

--- a/test/index.js
+++ b/test/index.js
@@ -16,7 +16,7 @@ tape('simple', function (t) {
     })
   )
 
-  notify(r)
+  t.equal(notify(r), r)
   notify.end()
 })
 
@@ -49,23 +49,6 @@ tape('end', function (t) {
       t.equal(data, r)
     }, function () {
       if (--n) return
-      t.end()
-    })
-  )
-
-  notify(r)
-  notify.end()
-})
-
-tape('simple', function (t) {
-  var notify = Notify()
-  var r = Math.random()
-
-  pull(
-    notify.listen(),
-    pull.drain(function (data) {
-      t.equal(data, r)
-    }, function () {
       t.end()
     })
   )


### PR DESCRIPTION
since [`push-stream`](https://github.com/ahdinosaur/push-stream) (of which the core was more or less copied from [`geval`](https://github.com/Raynos/geval)) did well on @Hypercubed's [observable benchmark](https://github.com/Hypercubed/EventsSpeedTests), i thought it might be worth a try to re-write `pull-notify` using the same pattern.

changes:
- how to keep track of listeners
  - before: an object where keys are incrementing integers
  - after: an array
- how to notify listeners
  - before: iterate through keys with `for in` loop
  - after: iterate through indexes with `for` loop
- how to add listener
  - before: generate new key and set on object
  - after: push to array
- how to remove listener
  - before: delete the key from object
  - after: find index of listener with `indexOf` and remove with `splice`

benchmark [before](https://github.com/Hypercubed/EventsSpeedTests/blob/master/results/node-v6.2.tap.md) and [after](https://gist.github.com/ahdinosaur/6e72863d851516af3de1610217ce2766)

also updated code to standard style, per https://github.com/pull-stream/pull-stream/issues/52.

/cc @dominictarr
