### PR TITLE
Change example

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ var notify = Notify()
 
 //create a pull stream that listens on events.
 //it will eventually get all events.
-pull(notify.listen(), pull.drain(console.log))
+pull(notify.listen(), pull.drain((evt) => console.log(evt)))
 
 notify('hello') //emit an event.
 


### PR DESCRIPTION
Pulling the example code together causes an `Uncaught exception TypeError: Illegal invocation` to be thrown on `drain.js:24`

![image](https://cloud.githubusercontent.com/assets/193412/16537329/dffd915a-3fb4-11e6-8b05-a93b4186c541.png)

``` js
const pull = require('pull-stream')
const Notify = require('pull-notify')

const notify = Notify()

pull(notify.listen(), pull.drain(console.log))

notify('hello', 'world')
notify.end()
```

[requirebin link](http://requirebin.com/?gist=01253780c25ce4a6675b8e54fac7c1d0)

This is because, at least in Chrome, the `console` object must be bound to the `console` object for `this`.

This change shows an example that can work in the browser.  Alternatively you could also do `console.log.bind(console)`.

Not sure which one is cleaner.  This might also be fixable in pull-streams.  IDK - this is my first foray into them ever :)
