### PR TITLE
fix infinite while loop upon end()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+pnpm-lock.yaml
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "type": "git",
     "url": "git://github.com/dominictarr/pull-notify.git"
   },
+  "files": [
+    "*.js"
+  ],
   "dependencies": {
     "pull-pushable": "^2.0.0"
   },
@@ -16,7 +19,6 @@
     "tape": "~4.0.0"
   },
   "scripts": {
-    "prepublish": "npm ls && npm test",
     "test": "standard && tape test/*.js"
   },
   "author": "Dominic Tarr <dominic.tarr@gmail.com> (http://dominictarr.com)",

--- a/test/index.js
+++ b/test/index.js
@@ -56,3 +56,22 @@ tape('end', function (t) {
   t.equal(notify(r), r)
   notify.end()
 })
+
+tape('end immediately upon delivery', function (t) {
+  var notify = Notify()
+  var r = Math.random()
+  var n = 1
+
+  pull(
+    notify.listen(),
+    pull.drain(function (data) {
+      t.equal(data, r)
+      notify.end()
+    }, function () {
+      if (--n) return
+      t.end()
+    })
+  )
+
+  t.equal(notify(r), r)
+})


### PR DESCRIPTION
## Context

I was working on ssb-room-client and added a simple `sbot.close.hook` that calls `myPullNotify.end()` and then somehow my tests got stuck on an infinite loop.

## Problem

This module doesn't remove listeners on `abort()`, instead, it lets listeners (all of which are pull-pushable) remove themselves on their onClose callback. The problem is that inside pull-pushable, in the "end" logic there is a `if (!cb) return` which means that the onClose is never called, and then in pull-notify these listeners don't get removed, so the `while` loop just keeps on going forever.

## Solution

1st commit adds a failing test.

2nd commit fixes the test. The while loop is finite because it removes the listeners. There's also extra provision with a `closed` flag to make sure that notify for-loop doesn't get into problems.

For extra measure, I put these changes into my Manyverse in production on my phone, and so far no bugs nor crashes. Seems safe to merge.